### PR TITLE
Add extensive unit tests

### DIFF
--- a/src/test/java/com/example/pk_pl/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/pk_pl/controller/AuthControllerTest.java
@@ -1,0 +1,42 @@
+package com.example.pk_pl.controller;
+
+import com.example.pk_pl.dto.AuthenticationResponse;
+import com.example.pk_pl.model.User;
+import com.example.pk_pl.service.AuthService;
+import com.example.pk_pl.service.DayOfWeekService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+public class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private AuthService authService;
+    @MockBean
+    private DayOfWeekService dayOfWeekService;
+
+    @Test
+    void registerReturnsCreated() throws Exception {
+        when(authService.register(any())).thenReturn(new AuthenticationResponse("a","r"));
+        mockMvc.perform(post("/auth/register").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isCreated());
+        verify(dayOfWeekService).createDaysOfWeek(any());
+    }
+
+    @Test
+    void loginReturnsOk() throws Exception {
+        when(authService.authenticate(any())).thenReturn(new AuthenticationResponse("a","r"));
+        mockMvc.perform(post("/auth/login").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/example/pk_pl/controller/DayOfWeekControllerTest.java
+++ b/src/test/java/com/example/pk_pl/controller/DayOfWeekControllerTest.java
@@ -1,0 +1,43 @@
+package com.example.pk_pl.controller;
+
+import com.example.pk_pl.dto.ScheduleUpdateRequest;
+import com.example.pk_pl.model.Activity;
+import com.example.pk_pl.model.DayOfWeek;
+import com.example.pk_pl.model.WeekDay;
+import com.example.pk_pl.service.DayOfWeekService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DayOfWeekController.class)
+public class DayOfWeekControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private DayOfWeekService service;
+
+    @Test
+    void getDaysReturnsOk() throws Exception {
+        when(service.getDaysOfWeek(any())).thenReturn(List.of(new DayOfWeek()));
+        mockMvc.perform(get("/days-of-week"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void updateScheduleReturnsCreated() throws Exception {
+        when(service.updateSchedule(any(), any(ScheduleUpdateRequest.class))).thenReturn(List.of(new DayOfWeek()));
+        mockMvc.perform(put("/days-of-week").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/example/pk_pl/controller/FlexibleEventsControllerTest.java
+++ b/src/test/java/com/example/pk_pl/controller/FlexibleEventsControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.pk_pl.controller;
+
+import com.example.pk_pl.model.FlexibleEvent;
+import com.example.pk_pl.service.FlexibleEventService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FlexibleEventsController.class)
+public class FlexibleEventsControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private FlexibleEventService service;
+
+    @Test
+    void upcomingReturnsOk() throws Exception {
+        when(service.getUpcomingFlexibleEvents(any())).thenReturn(List.of());
+        mockMvc.perform(get("/flexible-events/upcoming"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void addReturnsCreated() throws Exception {
+        when(service.saveFlexibleEvent(any())).thenReturn(new FlexibleEvent());
+        mockMvc.perform(post("/flexible-events").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/example/pk_pl/controller/GoalControllerTest.java
+++ b/src/test/java/com/example/pk_pl/controller/GoalControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.pk_pl.controller;
+
+import com.example.pk_pl.model.Goal;
+import com.example.pk_pl.service.GoalService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GoalController.class)
+public class GoalControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private GoalService service;
+
+    @Test
+    void getGoalsOk() throws Exception {
+        when(service.getGoals(any())).thenReturn(List.of());
+        mockMvc.perform(get("/goals"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void addGoalCreated() throws Exception {
+        when(service.saveGoal(any())).thenReturn(new Goal());
+        mockMvc.perform(post("/goals").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/example/pk_pl/controller/PingControllerTest.java
+++ b/src/test/java/com/example/pk_pl/controller/PingControllerTest.java
@@ -1,0 +1,21 @@
+package com.example.pk_pl.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PingController.class)
+public class PingControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void pingReturnsOk() throws Exception {
+        mockMvc.perform(get("/ping"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/example/pk_pl/controller/PlannedEventControllerTest.java
+++ b/src/test/java/com/example/pk_pl/controller/PlannedEventControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.pk_pl.controller;
+
+import com.example.pk_pl.model.PlannedEvent;
+import com.example.pk_pl.service.PlannedEventService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PlannedEventController.class)
+public class PlannedEventControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private PlannedEventService service;
+
+    @Test
+    void upcomingReturnsOk() throws Exception {
+        when(service.getUpcomingPlannedEvents(any())).thenReturn(List.of());
+        mockMvc.perform(get("/planned-events/upcoming"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void addReturnsCreated() throws Exception {
+        when(service.savePlannedEvent(any())).thenReturn(new PlannedEvent());
+        mockMvc.perform(post("/planned-events").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/example/pk_pl/service/AuthServiceTest.java
+++ b/src/test/java/com/example/pk_pl/service/AuthServiceTest.java
@@ -1,0 +1,99 @@
+package com.example.pk_pl.service;
+
+import com.example.pk_pl.dao.UserDao;
+import com.example.pk_pl.dto.AuthenticationResponse;
+import com.example.pk_pl.exception.ConflictException;
+import com.example.pk_pl.model.User;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class AuthServiceTest {
+
+    @Mock
+    private UserDao userDao;
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private BCryptPasswordEncoder encoder;
+    @InjectMocks
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void registerEncodesPasswordAndSavesUser() {
+        User user = new User("user", "test@test.com", "raw");
+        when(userDao.existsByEmail(user.getEmail())).thenReturn(false);
+        when(userDao.existsByUsername(user.getRealUsername())).thenReturn(false);
+        when(encoder.encode("raw")).thenReturn("enc");
+        when(jwtService.generateAccessToken(anyString())).thenReturn("a");
+        when(jwtService.generateRefreshToken(anyString())).thenReturn("r");
+
+        AuthenticationResponse response = authService.register(user);
+
+        verify(userDao).save(user);
+        assertEquals("enc", user.getPassword());
+        assertEquals("a", response.getAccessToken());
+    }
+
+    @Test
+    void registerThrowsIfEmailExists() {
+        User user = new User("user","e","p");
+        when(userDao.existsByEmail("e")).thenReturn(true);
+        assertThrows(ConflictException.class, () -> authService.register(user));
+    }
+
+    @Test
+    void authenticateCallsAuthenticationManager() {
+        User user = new User("u","e","p");
+        when(jwtService.generateAccessToken(anyString())).thenReturn("a");
+        when(jwtService.generateRefreshToken(anyString())).thenReturn("r");
+
+        AuthenticationResponse response = authService.authenticate(user);
+
+        verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        assertEquals("a", response.getAccessToken());
+    }
+
+    @Test
+    void refreshTokenReturnsUnauthorizedWhenNoUser() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(null);
+        ResponseEntity<AuthenticationResponse> resp = authService.refreshToken(req);
+        assertEquals(401, resp.getStatusCode().value());
+    }
+
+    @Test
+    void extractUserFromRequestSuccess() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer token");
+        when(jwtService.extractUsername("token")).thenReturn("e");
+        User user = new User();
+        when(userDao.findByEmail("e")).thenReturn(Optional.of(user));
+        when(jwtService.isValid("token", user)).thenReturn(true);
+
+        User result = authService.extractUserFromRequest(req);
+        assertSame(user, result);
+    }
+}

--- a/src/test/java/com/example/pk_pl/service/DayOfWeekServiceTest.java
+++ b/src/test/java/com/example/pk_pl/service/DayOfWeekServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.pk_pl.service;
+
+import com.example.pk_pl.dao.ActivityDao;
+import com.example.pk_pl.dao.DayOfWeekDao;
+import com.example.pk_pl.dao.GoalDao;
+import com.example.pk_pl.dto.ScheduleUpdateRequest;
+import com.example.pk_pl.model.Activity;
+import com.example.pk_pl.model.DayOfWeek;
+import com.example.pk_pl.model.User;
+import com.example.pk_pl.model.WeekDay;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class DayOfWeekServiceTest {
+    @Mock
+    private DayOfWeekDao dayOfWeekDao;
+    @Mock
+    private ActivityDao activityDao;
+    @Mock
+    private GoalDao goalDao;
+    @InjectMocks
+    private DayOfWeekService service;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createDaysOfWeekCreatesSevenEntries() {
+        User user = new User();
+        service.createDaysOfWeek(user);
+        verify(dayOfWeekDao).saveAll(argThat(list -> list.size() == 7));
+    }
+
+    @Test
+    void getDayOfWeekNotFoundThrows() {
+        when(dayOfWeekDao.findByUserAndDay(any(), any())).thenReturn(Optional.empty());
+        assertThrows(NoSuchElementException.class, () -> service.getDayOfWeek(new User(), WeekDay.MONDAY));
+    }
+
+    @Test
+    void updateScheduleDeletesAndAddsActivities() {
+        ScheduleUpdateRequest req = new ScheduleUpdateRequest();
+        req.setIdsToDelete(List.of(1));
+        Map<WeekDay,List<Activity>> toAdd = new EnumMap<>(WeekDay.class);
+        toAdd.put(WeekDay.MONDAY, List.of(new Activity()));
+        req.setActivitiesToAdd(toAdd);
+        DayOfWeek day = new DayOfWeek();
+        when(dayOfWeekDao.findByUserAndDay(any(), eq(WeekDay.MONDAY))).thenReturn(Optional.of(day));
+        when(dayOfWeekDao.findAll()).thenReturn(List.of(day));
+        List<DayOfWeek> result = service.updateSchedule(new User(), req);
+        verify(activityDao).deleteAllById(req.getIdsToDelete());
+        verify(activityDao).saveAll(anyList());
+        assertEquals(1, result.size());
+    }
+}

--- a/src/test/java/com/example/pk_pl/service/FlexibleEventServiceTest.java
+++ b/src/test/java/com/example/pk_pl/service/FlexibleEventServiceTest.java
@@ -1,0 +1,46 @@
+package com.example.pk_pl.service;
+
+import com.example.pk_pl.dao.FlexibleEventDao;
+import com.example.pk_pl.model.FlexibleEvent;
+import com.example.pk_pl.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class FlexibleEventServiceTest {
+    @Mock
+    private FlexibleEventDao dao;
+    @InjectMocks
+    private FlexibleEventService service;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getUpcomingCallsDao() {
+        User user = new User();
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC).minusDays(1);
+        when(dao.findByUserAndEndDateAfterOrderByStartDateAsc(any(), any())).thenReturn(List.of(new FlexibleEvent()));
+        List<FlexibleEvent> res = service.getUpcomingFlexibleEvents(user);
+        assertEquals(1, res.size());
+    }
+
+    @Test
+    void saveDelegatesToDao() {
+        FlexibleEvent e = new FlexibleEvent();
+        when(dao.save(e)).thenReturn(e);
+        assertSame(e, service.saveFlexibleEvent(e));
+    }
+}

--- a/src/test/java/com/example/pk_pl/service/GoalServiceTest.java
+++ b/src/test/java/com/example/pk_pl/service/GoalServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.pk_pl.service;
+
+import com.example.pk_pl.dao.GoalDao;
+import com.example.pk_pl.dao.StepDao;
+import com.example.pk_pl.model.Goal;
+import com.example.pk_pl.model.Step;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class GoalServiceTest {
+    @Mock
+    private GoalDao goalDao;
+    @Mock
+    private StepDao stepDao;
+    @InjectMocks
+    private GoalService service;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void addStepToGoalAddsAndReorders() {
+        Goal goal = new Goal();
+        List<Step> steps = new ArrayList<>();
+        Step s1 = new Step(); s1.setOrderIndex(1); steps.add(s1);
+        Step s2 = new Step(); s2.setOrderIndex(2); steps.add(s2);
+        goal.setSteps(steps);
+        when(goalDao.findById(1)).thenReturn(Optional.of(goal));
+        Step newStep = new Step(); newStep.setOrderIndex(1);
+        when(stepDao.save(any(Step.class))).thenReturn(newStep);
+        Step result = service.addStepToGoal(1, newStep);
+        verify(stepDao).saveAll(steps);
+        assertEquals(1, result.getOrderIndex());
+    }
+
+    @Test
+    void deleteStepReordersRemaining() {
+        Goal goal = new Goal();
+        Step s1 = new Step(); s1.setId(1); s1.setOrderIndex(1);
+        Step s2 = new Step(); s2.setId(2); s2.setOrderIndex(2);
+        List<Step> steps = new ArrayList<>(); steps.add(s1); steps.add(s2);
+        goal.setSteps(steps);
+        s1.setGoal(goal); s2.setGoal(goal);
+        when(stepDao.findById(2)).thenReturn(Optional.of(s2));
+        service.deleteStep(2);
+        verify(stepDao).saveAll(anyList());
+        verify(stepDao).delete(s2);
+        assertEquals(1, steps.get(0).getOrderIndex());
+    }
+}

--- a/src/test/java/com/example/pk_pl/service/JwtServiceTest.java
+++ b/src/test/java/com/example/pk_pl/service/JwtServiceTest.java
@@ -1,0 +1,44 @@
+package com.example.pk_pl.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JwtServiceTest {
+
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+        // set a constant secret key for tests
+        String secret = "MySecretKey12345678901234567890123456789012"; // 48 bytes base64 -> 32 bytes
+        ReflectionTestUtils.setField(jwtService, "secretKey", java.util.Base64.getEncoder().encodeToString(secret.getBytes()));
+        ReflectionTestUtils.setField(jwtService, "accessTokenExp", 1000L);
+        ReflectionTestUtils.setField(jwtService, "refreshTokenExp", 2000L);
+    }
+
+    @Test
+    void generateAndValidateAccessToken() {
+        String token = jwtService.generateAccessToken("user@example.com");
+        assertNotNull(token);
+        String username = jwtService.extractUsername(token);
+        assertEquals("user@example.com", username);
+    }
+
+    @Test
+    void tokenValidation() {
+        String token = jwtService.generateAccessToken("test@user.com");
+        // user details implementation not needed, use simple implementation
+        org.springframework.security.core.userdetails.User user =
+                new org.springframework.security.core.userdetails.User("test@user.com", "pass", java.util.Collections.emptyList());
+        assertTrue(jwtService.isValid(token, user));
+    }
+}

--- a/src/test/java/com/example/pk_pl/service/PlannedEventServiceTest.java
+++ b/src/test/java/com/example/pk_pl/service/PlannedEventServiceTest.java
@@ -1,0 +1,51 @@
+package com.example.pk_pl.service;
+
+import com.example.pk_pl.dao.EventDetailsDao;
+import com.example.pk_pl.dao.PlannedEventDao;
+import com.example.pk_pl.model.EventDetails;
+import com.example.pk_pl.model.PlannedEvent;
+import com.example.pk_pl.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class PlannedEventServiceTest {
+    @Mock
+    private PlannedEventDao plannedEventDao;
+    @Mock
+    private EventDetailsDao eventDetailsDao;
+    @InjectMocks
+    private PlannedEventService service;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getUpcomingEventsCallsDao() {
+        when(plannedEventDao.findByUserAndScheduledDateAfterOrderByScheduledDateAsc(any(), any())).thenReturn(List.of(new PlannedEvent()));
+        List<PlannedEvent> res = service.getUpcomingPlannedEvents(new User());
+        assertEquals(1, res.size());
+    }
+
+    @Test
+    void savePlannedEventSetsEventDetails() {
+        PlannedEvent event = new PlannedEvent();
+        EventDetails details = new EventDetails();
+        event.setEventDetails(List.of(details));
+        when(plannedEventDao.save(event)).thenReturn(event);
+        PlannedEvent saved = service.savePlannedEvent(event);
+        assertSame(event, saved);
+        assertEquals(event, details.getPlannedEvent());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for service layer covering auth, day of week logic, flexible/planned events, JWT, and goals
- add controller tests using MockMvc for all REST endpoints

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6879201edd648325b630e06e9f6a383f